### PR TITLE
Dereference symlinks before invoking prettier CLI

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,4 +2,17 @@
  * Bun entrypoint for prettier cli
  */
 
-await require("prettier/internal/cli.mjs").run();
+import { readlinkSync } from "fs";
+import "process";
+
+const resolvedArgv = process.argv.slice(2).map((arg) => {
+  if (arg.startsWith("--") || arg.startsWith("-")) {
+    // Propagate flags without modifications
+    return arg;
+  }
+  // If the arg is a file to lint, dereference symlinks
+  return readlinkSync(arg);
+});
+
+const exitCode = await require("prettier/internal/cli.mjs").run(resolvedArgv);
+process.exit(exitCode);


### PR DESCRIPTION
## Summary

Prettier made an active decision to move away from resolving symlinks (see https://github.com/prettier/prettier/pull/14627), which is inconvenient when running it against files that are symlinked in a Bazel sandbox. This PR dereferences symlinks in the wrapper before invoking the main CLI