### PR TITLE
Fix symlink dereferencing & clean up entrypoint

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,16 +2,18 @@
  * Bun entrypoint for prettier cli
  */
 
-import { readlinkSync } from "fs";
+import { readlinkSync, statSync } from "fs";
 import "process";
 
 const resolvedArgv = process.argv.slice(2).map((arg) => {
-  if (arg.startsWith("--") || arg.startsWith("-")) {
-    // Propagate flags without modifications
+  // Propagate flags without modifications
+  if (arg.startsWith("-")) {
     return arg;
   }
-  // If the arg is a file to lint, dereference symlinks
-  return readlinkSync(arg);
+
+  // If the arg is a file to lint, dereference symlinks if necessary
+  const stats = statSync(arg);
+  return stats.isSymbolicLink() ? readlinkSync(arg) : arg;
 });
 
 const exitCode = await require("prettier/internal/cli.mjs").run(resolvedArgv);


### PR DESCRIPTION
## Summary

This PR fixes the entrypoint behavior to only dereference symlinks if the argument is in fact a symlink (o/w `readlink` throws), and cleans up the flag passthrough 