### PR TITLE
Use `lstat` to properly dereference symlinks & add integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
       - name: install
         shell: bash
         run: bun install
-      - name: build & package
+      - name: test
         shell: bash
         env:
           PLATFORM: ${{ matrix.platform }}
           ARCH: ${{ matrix.arch }}
           VERSION: "0.0.0"
         run: |
-          bun run package
+          bun run test
           ./dist/prettier --version

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
  * Bun entrypoint for prettier cli
  */
 
-import { readlinkSync, statSync } from "fs";
+import { realpathSync, lstatSync } from "fs";
 import "process";
 
 const resolvedArgv = process.argv.slice(2).map((arg) => {
@@ -12,8 +12,8 @@ const resolvedArgv = process.argv.slice(2).map((arg) => {
   }
 
   // If the arg is a file to lint, dereference symlinks if necessary
-  const stats = statSync(arg);
-  return stats.isSymbolicLink() ? readlinkSync(arg) : arg;
+  const stats = lstatSync(arg);
+  return stats.isSymbolicLink() ? realpathSync(arg) : arg;
 });
 
 const exitCode = await require("prettier/internal/cli.mjs").run(resolvedArgv);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "clean": "rm -rf dist/ node_modules/",
     "cli": "bun run ./index.ts",
-    "package": "bun build ./index.ts --compile --outfile dist/prettier"
+    "package": "bun build ./index.ts --compile --outfile dist/prettier",
+    "test": "./test/integration_test.sh"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PRETTIER_BIN="./dist/prettier"
+REAL_PATH="test/test.yaml"
+SYMLINK_PATH="test/test-symlink.yaml"
+
+bun run package
+
+# Run tests
+"$PRETTIER_BIN" "$REAL_PATH" > /dev/null
+"$PRETTIER_BIN" "$SYMLINK_PATH" > /dev/null
+

--- a/test/test-symlink.yaml
+++ b/test/test-symlink.yaml
@@ -1,0 +1,1 @@
+test.yaml

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -1,0 +1,3 @@
+foo:
+  bar: baz
+


### PR DESCRIPTION
## Issue
The last change only partially fixed the issue when running inside a Bazel runfiles sandbox and led to issues w/ direct usage of the CLI

## Summary
Use `lstat` instead of `stat` when determining if a prettier CLI argument is a symlink, & add an e2e test (which fails prior to the `lstat` fix)