### PR TITLE
Fix artifact strings

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,7 +35,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
           VERSION: ${{ github.ref_name }}
         run: |
-          PREFIX="prettier-${PLATFORM/x64/amd64}-${ARCH}-${VERSION}"
+          PREFIX="prettier-${PLATFORM/mac/darwin}-${ARCH/x64/amd64}-${VERSION}"
 
           pushd dist/ > /dev/null
           tar -cvzf "${PREFIX}.tar.gz" prettier


### PR DESCRIPTION
In #5 I had the substitutions wrong. Fix artifact strings to preserve consistent names for releases.
